### PR TITLE
fix the download hash

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/biosustain/swiglpk/archive/{{ version }}.tar.gz
-  sha256: 67af24372d4ed00d2d4f1e44f02e50983abaccd91f4eee07e00bb4eb00cd846f
+  sha256: cc58d0ee24ac56ba5d7db80241bbdaa9d44b94eac7cfa3d108a066f948486dea
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Not sure why it is necessary but the hash was wrong on this one. I verified that the new hash is correct for the used download link.